### PR TITLE
Remove `artifact` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ plugins {
     id("io.spine.prototap") version "$version"
 }
 ```
-The above snippet assumes that the plugin with the ID `"com.google.protobuf"` is already added at
-some level to your project.
+The above snippet assumes that the plugin with the ID `"com.google.protobuf"` is already
+added and configured in your project.
 
 > [!TIP]
 > For the latest ProtoTap version please see [`version.gradle.kts`](version.gradle.kts).
@@ -83,14 +83,10 @@ You can tune ProtoTap by using the following DSL:
 
 ```kotlin
 prototap {
-    artifact.set("com.google.protobuf:protoc:3.25.1")
     sourceSet.set(functionalTest)
     generateDescriptorSet.set(true)
 }
 ```
-The `artifact` property is a convenience shortcut for specifying the `protoc` artifact in case
-your project does not have explicit `protobuf` block.
-
 The `sourceSet` property is for specifying a source set with the proto files of interest, other
 than `testFixtures` or `test`.
 

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:prototap-api:0.8.1`
+# Dependencies of `io.spine.tools:prototap-api:0.8.2`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 24.0.1.
@@ -480,12 +480,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 01 16:08:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 02 19:06:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:prototap-gradle-plugin:0.8.1`
+# Dependencies of `io.spine.tools:prototap-gradle-plugin:0.8.2`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1243,12 +1243,12 @@ This report was generated on **Wed May 01 16:08:15 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 01 16:08:15 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 02 19:06:54 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:prototap-protoc-plugin:0.8.1`
+# Dependencies of `io.spine.tools:prototap-protoc-plugin:0.8.2`
 
 ## Runtime
 1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.25.1.
@@ -1732,4 +1732,4 @@ This report was generated on **Wed May 01 16:08:15 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 01 16:08:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 02 19:06:54 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -480,7 +480,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 02 19:06:53 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 02 19:21:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1243,7 +1243,7 @@ This report was generated on **Thu May 02 19:06:53 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 02 19:06:54 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 02 19:21:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1732,4 +1732,4 @@ This report was generated on **Thu May 02 19:06:54 WEST 2024** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 02 19:06:54 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 02 19:21:14 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/gradle-plugin/src/main/kotlin/io/spine/tools/prototap/gradle/Extension.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/tools/prototap/gradle/Extension.kt
@@ -42,19 +42,6 @@ import org.gradle.kotlin.dsl.property
 public class Extension(project: Project) {
 
     /**
-     * The `protoc` artifact to be used during for processing proto files.
-     *
-     * The default value is empty string, which means that ProtoTap assumes that it
-     * is used in a project with Protobuf Gradle Plugin fully configured.
-     *
-     * This property can be used in rare cases when the artifact is not specified directly
-     * via the [artifact][com.google.protobuf.gradle.ExecutableLocator.setArtifact] property in
-     * the [protobuf/protoc][com.google.protobuf.gradle.ProtobufExtension.protoc] block.
-     */
-    public val artifact: Property<String> = project.objects.property<String>()
-        .convention("")
-
-    /**
      * The source set with proto files for installing the tap.
      *
      * If not specified the Gradle plugin would look for

--- a/gradle-plugin/src/main/kotlin/io/spine/tools/prototap/gradle/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/tools/prototap/gradle/Plugin.kt
@@ -96,7 +96,6 @@ private fun Project.createExtension(): Extension {
  * Protobuf Gradle Plugin.
  */
 private fun Project.tapProtobuf() {
-    setProtocArtifact()
     createProtocPlugin()
     tuneProtoTasks()
 }
@@ -106,15 +105,6 @@ private fun Project.tapProtobuf() {
  */
 private val Project.extension: Extension
     get() = extensions.getByType(Extension::class.java)
-
-private fun Project.setProtocArtifact() = protobufExtension?.run {
-    protoc {
-        val artifact = extension.artifact.get()
-        if (artifact.isNotBlank()) {
-            it.artifact = artifact
-        }
-    }
-}
 
 private fun Project.createProtocPlugin() = protobufExtension?.run {
     plugins {

--- a/gradle-plugin/src/test/resources/with-settings/build.gradle.kts
+++ b/gradle-plugin/src/test/resources/with-settings/build.gradle.kts
@@ -84,7 +84,6 @@ testing {
 val functionalTest: SourceSet by project.sourceSets.getting
 
 prototap {
-    artifact.set(io.spine.internal.dependency.Protobuf.compiler)
     sourceSet.set(functionalTest)
     generateDescriptorSet.set(true)
 }

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>ProtoTap</artifactId>
-<version>0.8.1</version>
+<version>0.8.2</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("0.8.1")
+val versionToPublish: String by extra("0.8.2")


### PR DESCRIPTION
This PR removes the `artifact` setting from ProtoTap Gradle project extension. 

We do require Protobuf Gradle Plugin configured in the same project to which ProtoTap is applied. 
Because of this the `artifact` property of `ExecutorLocator` should be already configured. 

Having a separate property of ProtoTap project extension which simply propagates its value to the Protobuf Gradle plugin project extension requires additional project configuration for little to no gain.

Also, having a property which does the same as the one from `protobuf` extension, introduces some confusion, Which one should I use?  What happens if different values supplied? Which one has a priority? Why do we have two ways for doing the same thing? Etc.

Because of the above reasons we decided to simply remove the property.
